### PR TITLE
reduce the image size by building singularity in a separate stage

### DIFF
--- a/replicator/Dockerfile
+++ b/replicator/Dockerfile
@@ -1,16 +1,8 @@
-COPY requirements.txt /tmp/requirements.txt
-RUN pip install -r /tmp/requirements.txt && rm -f /tmp/requirements.txt
+ARG BASE_IMAGE=deepops_python
+FROM $BASE_IMAGE AS singularity
 
-WORKDIR /source/ngc_replicator
-COPY . .
-RUN mkdir -p /output
-RUN python setup.py install
-ENTRYPOINT ["ngc_replicator"]
-
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        jq && \
-    rm -rf /var/lib/apt/lists/*
+ARG APT_PROXY=false
+RUN echo "Acquire::HTTP::Proxy \"$APT_PROXY\";" >> /etc/apt/apt.conf.d/01proxy
 
 # Singularity build requirements
 RUN apt-get update -y && \
@@ -41,10 +33,38 @@ RUN mkdir -p /tmp && wget -q -nc --no-check-certificate -P /tmp https://github.c
     cd $GOPATH/src/github.com/sylabs/singularity && \
     go get -u -v github.com/golang/dep/cmd/dep && \
     cd $GOPATH/src/github.com/sylabs/singularity && \
-    ./mconfig && \
+    ./mconfig --prefix=/usr/local/singularity && \
     cd builddir && \
     make && \
     make install && \
     rm -rf /tmp/singularity-3.2.1.tar.gz
 
+FROM $BASE_IMAGE
+
+ARG APT_PROXY=false
+RUN echo "Acquire::HTTP::Proxy \"$APT_PROXY\";" >> /etc/apt/apt.conf.d/01proxy
+
+# Singularity
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        squashfs-tools && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=singularity /usr/local/singularity /usr/local/singularity
+ENV PATH=/usr/local/singularity/bin:$PATH
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt && rm -f /tmp/requirements.txt
+
+WORKDIR /source/ngc_replicator
+COPY . .
+RUN mkdir -p /output
+RUN python setup.py install
+ENTRYPOINT ["ngc_replicator"]
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        jq && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY scripts/docker-utils /usr/bin/docker-utils
+
+RUN rm -f /etc/apt/apt.conf.d/01proxy

--- a/replicator/Makefile
+++ b/replicator/Makefile
@@ -4,18 +4,13 @@ RELEASE_VERSION=0.3.5
 RELEASE_IMAGE ?= deepops/replicator
 
 APT_PROXY ?= "false"
-CACHE="RUN echo 'Acquire::HTTP::Proxy \"${APT_PROXY}\";' >> /etc/apt/apt.conf.d/01proxy"
 
 .PHONY: build tag push release clean distclean
 
-default: clean build
+default: build
 
 build:
-	@echo FROM ${BASE_IMAGE} > .Dockerfile
-	@echo ${CACHE} >> .Dockerfile
-	@cat Dockerfile >> .Dockerfile
-	@echo "RUN rm -f /etc/apt/apt.conf.d/01proxy" >> .Dockerfile
-	docker build -t ${IMAGE_NAME} -f .Dockerfile .
+	docker build --build-arg BASE_IMAGE=${BASE_IMAGE} --build-arg APT_PROXY=${APT_PROXY} -t ${IMAGE_NAME} -f Dockerfile .
 
 dev: build
 	docker build ${CACHES} -t ${IMAGE_NAME}:dev -f Dockerfile.test .


### PR DESCRIPTION
- simplify build with build args
- remove clean from default make target to preserve the first container stage