### PR TITLE
Fix to deal with a empty image list.

### DIFF
--- a/python/nvidia_deepops/docker/registry/ngcregistry.py
+++ b/python/nvidia_deepops/docker/registry/ngcregistry.py
@@ -249,7 +249,8 @@ class NGCRegistry(BaseRegistry):
         """
         org_name, repo_name = image_name.split('/')
         endpoint = "org/{}/repos/{}/images".format(org_name, repo_name)
-        return self._get(endpoint)['images']
+        response = self._get(endpoint)
+        return response['images'] if 'images' in response else []
 
     def get_state(self, project=None, filter_fn=None):
         names = self.get_image_names(project=project)

--- a/python/nvidia_deepops/docker/registry/ngcregistry.py
+++ b/python/nvidia_deepops/docker/registry/ngcregistry.py
@@ -249,8 +249,7 @@ class NGCRegistry(BaseRegistry):
         """
         org_name, repo_name = image_name.split('/')
         endpoint = "org/{}/repos/{}/images".format(org_name, repo_name)
-        response = self._get(endpoint)
-        return response['images'] if 'images' in response else []
+        return self._get(endpoint).get('images', [])
 
     def get_state(self, project=None, filter_fn=None):
         names = self.get_image_names(project=project)


### PR DESCRIPTION
_get_image_data() function assumes that the dictionary returned by _get() contains "images" key, but if there are no images (e.g. Current Clara Deploy SDK has no image), the "images" key does not exist and Replicator stop with "KeyError: 'images'".
This pull request will fix #13 .