### PR TITLE
Add flag to make image name matching strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/output
                        --api-key=<your-dgx-or-ngc-api-key>
 ```
 
-You can also filter on specific images.  If you only wanted Tensorflow, PyTorch
-and TensorRT, you would simply add `--image` for each option, e.g.
+You can also filter on specific images.
+If you want to filter only on image names containing the strings "tensorflow",
+"pytorch", and "tensorrt", you would simply add `--image` for each option, e.g.
 
 ```
 docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/output \
@@ -33,6 +34,23 @@ docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/output
 
 Note: the `--dry-run` option lets you see what will happen without committing
 to a lengthy download.
+
+By default, the `--image` flag does a substring match in order to ensure you match
+all images that may be desired.
+Sometimes, however, you only want to download a specific image with no substring
+matching.
+In this case, you can add the `--strict-name-match` flag, e.g.
+
+```
+docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/output \
+    deepops/replicator --project=nvidia --min-version=17.12 \
+                       --image=nvidia/tensorflow \
+                       --strict-name-match \
+                       --dry-run \
+                       --api-key=<your-dgx-or-ngc-api-key>
+```
+
+Note: when using `--strict-name-match`, the image name must be specified as a full name including project.
 
 Note: a `state.yml` file will be created the output directory.  This saved state will be used to
 avoid pulling images that were previously pulled.  If you wish to repull and save an image, just

--- a/README.md
+++ b/README.md
@@ -44,13 +44,11 @@ In this case, you can add the `--strict-name-match` flag, e.g.
 ```
 docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/output \
     deepops/replicator --project=nvidia --min-version=17.12 \
-                       --image=nvidia/tensorflow \
+                       --image=tensorflow \
                        --strict-name-match \
                        --dry-run \
                        --api-key=<your-dgx-or-ngc-api-key>
 ```
-
-Note: when using `--strict-name-match`, the image name must be specified as a full name including project.
 
 Note: a `state.yml` file will be created the output directory.  This saved state will be used to
 avoid pulling images that were previously pulled.  If you wish to repull and save an image, just

--- a/replicator/Dockerfile
+++ b/replicator/Dockerfile
@@ -21,23 +21,24 @@ RUN apt-get update -y && \
 
 # Go
 RUN cd /var/tmp && \
-    mkdir -p /tmp && wget -q -nc --no-check-certificate -P /tmp https://dl.google.com/go/go1.11.linux-amd64.tar.gz && \
-    mkdir -p /usr/local && tar -x -f /tmp/go1.11.linux-amd64.tar.gz -C /usr/local -z && \
-    rm -rf /tmp/go1.11.linux-amd64.tar.gz
+    mkdir -p /tmp && wget -q -nc --no-check-certificate -P /tmp https://dl.google.com/go/go1.13.linux-amd64.tar.gz && \
+    mkdir -p /usr/local && tar -x -f /tmp/go1.13.linux-amd64.tar.gz -C /usr/local -z && \
+    rm -rf /tmp/go1.13.linux-amd64.tar.gz
 ENV GOPATH=/root/go \
     PATH=/usr/local/go/bin:$PATH:/root/go/bin
 
 # Singularity
-RUN mkdir -p /tmp && wget -q -nc --no-check-certificate -P /tmp https://github.com/sylabs/singularity/releases/download/v3.2.1/singularity-3.2.1.tar.gz && \
-    mkdir -p $GOPATH/src/github.com/sylabs && tar -x -f /tmp/singularity-3.2.1.tar.gz -C $GOPATH/src/github.com/sylabs -z && \
+RUN mkdir -p /tmp && wget -q -nc --no-check-certificate -P /tmp https://github.com/sylabs/singularity/releases/download/v3.7.4/singularity-3.7.4.tar.gz && \
+    mkdir -p $GOPATH/src/github.com/sylabs && tar -x -f /tmp/singularity-3.7.4.tar.gz -C $GOPATH/src/github.com/sylabs -z && \
     cd $GOPATH/src/github.com/sylabs/singularity && \
+    go env -w GO111MODULE=off && \
     go get -u -v github.com/golang/dep/cmd/dep && \
     cd $GOPATH/src/github.com/sylabs/singularity && \
     ./mconfig --prefix=/usr/local/singularity && \
     cd builddir && \
     make && \
     make install && \
-    rm -rf /tmp/singularity-3.2.1.tar.gz
+    rm -rf /tmp/singularity-3.7.4.tar.gz
 
 FROM $BASE_IMAGE
 

--- a/replicator/ngc_replicator/ngc_replicator.py
+++ b/replicator/ngc_replicator/ngc_replicator.py
@@ -226,7 +226,7 @@ class Replicator:
                 if (not strict_name_match) and (image in name):
                     log.debug("{} passes filter; matches {}".format(name, image))
                     found = True
-                elif (strict_name_match) and image.strip() == name.strip():
+                elif (strict_name_match) and image.strip() == (name.split('/')[-1]).strip():
                     log.debug("{} passes strict filter; matches {}".format(name, image))
                     found = True
             if not found:


### PR DESCRIPTION
Currently the `--image` flag performs a substring match. This means that `--image=tensorflow` will match not only images named `nvidia/tensorflow`, but also `nvidia/l4t-tensorflow`.

A lot of the time this is what we want, as we want to download many images! However, sometimes you really do want to limit to only the desired images and not download anything extra.

This PR adds a flag `--strict-name-match` to make this matching strict and match only the exact name specified.

It also includes minor updates to the Dockerfile to allow it to build, as the previous version of Singularity used is no longer available for download.