### PR TITLE
Explicitly use UnsafeLoader to load config/state

### DIFF
--- a/replicator/ngc_replicator/ngc_replicator.py
+++ b/replicator/ngc_replicator/ngc_replicator.py
@@ -54,7 +54,7 @@ class Replicator:
         self.state = collections.defaultdict(dict)
         if os.path.exists(self.state_path):
             with open(self.state_path, "r") as file:
-                tmp = yaml.load(file)
+                tmp = yaml.load(file, Loader=yaml.UnsafeLoader)
             if tmp:
                 for key, val in tmp.items():
                     self.state[key] = val
@@ -71,7 +71,7 @@ class Replicator:
 
     def read_external_images_file(self):
         with open(self.config("external_images"), "r") as file:
-            data = yaml.load(file)
+            data = yaml.load(file, Loader=yaml.UnsafeLoader)
         images = data.get("images", [])
         images = [replicator_pb2.DockerImage(name=image["name"], tag=image.get("tag", "latest")) for image in images]
         return images


### PR DESCRIPTION
PR #22 merged an upgrade to PyYAML which broke our existing use of
yaml.load for configuration and state files.

Unfortunately, we can't use safe_load here because we make use of
`defaultdict` datastructures that don't work with this method:

```
yaml.constructor.ConstructorError: could not determine a constructor for the tag 'tag:yaml.org,2002:python/object/apply:collections.defaultdict'
```

So this PR explicitly uses the UnsafeLoader to load the config and state
files.

This should be fine, as we're not accepting any arbitrary data
from untrusted users for this configuration. Anyone who is using this
tool has Docker access, so should be assumed to be an administrator
anyway.